### PR TITLE
Quote after_success command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ env:
   - CFLAGS="-O0 --coverage" LDFLAGS="--coverage" COVERAGE=1
 
 after_success:
-  - [ -n "$COVERAGE" ] && coveralls --exclude test
+  - '[ -n "$COVERAGE" ] && coveralls --exclude test'


### PR DESCRIPTION
Special characters like & can break the YAML parser unfortunately.
